### PR TITLE
Add CSS snippet export for customized callouts

### DIFF
--- a/src/manager/CSSInjector.ts
+++ b/src/manager/CSSInjector.ts
@@ -329,6 +329,50 @@ export class CSSInjector {
 		}
 	}
 
+
+	/**
+	 * Generate a standalone CSS stylesheet containing all callouts
+	 * that the user has explicitly customized.
+	 *
+	 * This reuses the same CSS generation code used by the live
+	 * Callout Studio stylesheet, so exported callouts stay visually
+	 * consistent with the plugin.
+	 *
+	 * This includes:
+	 * - User-created callouts
+	 * - Built-in callouts that the user has modified
+	 *
+	 * It deliberately excludes:
+	 * - Unmodified built-in callouts
+	 * - Transient preview definitions
+	 * - The global Callout Studio styling
+	 * - The fallback catch-all rule
+	 */
+	generateExportCSS(): string {
+		const callouts = this.registry.getExportableDefinitions();
+
+		if (callouts.length === 0) {
+			return "";
+		}
+
+		const rules: string[] = [
+			"/* ============================================================",
+			"   Callout Studio — Custom Callouts",
+			"   Generated automatically. Do not edit manually.",
+			"   ============================================================ */",
+		];
+
+		for (const def of callouts) {
+			const css = this.generateCalloutCSS(def);
+			if (css.trim()) {
+				rules.push(css);
+			}
+		}
+
+		return rules.join("\n\n");
+	}
+	
+
 	private injectNow(emitCssChange: boolean): void {
 		this.ensureStyleSheet();
 

--- a/src/settings/sections/DataManagementSection.ts
+++ b/src/settings/sections/DataManagementSection.ts
@@ -6,7 +6,7 @@
  * validation (via importValidator), vault re-scan, and full data reset.
  * Uses ImportReportModal to surface validation issues before import.
  */
-import { Notice, Setting } from "obsidian";
+import { Notice, Setting, normalizePath } from "obsidian";
 import { t } from "../../i18n";
 import { ConfirmModal } from "../../utils/ConfirmModal";
 import { ImportReportModal } from "../../utils/ImportReportModal";
@@ -47,6 +47,20 @@ export function renderImportExportSection(
 			btn.setButtonText(t("settings.export"))
 				.setIcon("upload")
 				.onClick(() => exportCallouts(ctx));
+			btn.buttonEl.addClass("cs-settings-neutral-btn");
+		});
+
+	new Setting(containerEl)
+		.setName("Export CSS snippet")
+		.setDesc(
+			"Save your custom Callout Studio callouts as an Obsidian CSS snippet.",
+		)
+		.addButton((btn) => {
+			btn.setButtonText("Export CSS")
+				.setIcon("file-code")
+				.onClick(() => {
+					void exportCalloutCSS(ctx);
+				});
 			btn.buttonEl.addClass("cs-settings-neutral-btn");
 		});
 }
@@ -165,6 +179,54 @@ function exportCallouts(ctx: SettingsSectionContext): void {
 	URL.revokeObjectURL(url);
 	new Notice(t("notice.exported"));
 }
+
+
+/**
+ * Export Callout Studio's customized callouts as an Obsidian CSS snippet.
+ *
+ * The file is written directly into the vault's CSS snippets folder.
+ * Exporting again replaces the previous generated file.
+ */
+async function exportCalloutCSS(
+	ctx: SettingsSectionContext,
+): Promise<void> {
+	const css = ctx.plugin.cssInjector.generateExportCSS();
+
+	if (!css.trim()) {
+		new Notice("There are no custom callouts to export.");
+		return;
+	}
+
+	const snippetsDir = normalizePath(
+		`${ctx.app.vault.configDir}/snippets`,
+	);
+
+	const filePath = normalizePath(
+		`${snippetsDir}/callout-studio-custom.css`,
+	);
+
+	try {
+		if (!(await ctx.app.vault.adapter.exists(snippetsDir))) {
+			await ctx.app.vault.adapter.mkdir(snippetsDir);
+		}
+
+		await ctx.app.vault.adapter.write(filePath, css);
+
+		new Notice(
+			`CSS exported to ${filePath}`,
+		);
+	} catch (error) {
+		console.error(
+			"[Callout Studio] CSS export failed:",
+			error,
+		);
+
+		new Notice(
+			"Failed to export the CSS snippet. Check the developer console for details.",
+		);
+	}
+}
+
 
 /**
  * Parses and applies a Callout Studio JSON export. Takes an already-chosen


### PR DESCRIPTION
Allows for the exporting of custom and modified callouts for use with publishing via the Digital Garden plugin. Tested with GitHub Pages hosting.