### PR TITLE
Let a recovered session write again

### DIFF
--- a/internals-docs/07-persistence-and-caching.md
+++ b/internals-docs/07-persistence-and-caching.md
@@ -223,6 +223,11 @@ The two callers answer `unreadable` differently, and both answers matter:
   up holding only the built-ins — but `SettingsWriter.freeze()` takes the file
   off the table for the session and the user is told, because otherwise the very
   next save replaces a file we failed to understand with one we know is wrong.
+  It also registers `watchForLateSettings`, because "unreadable" is a transfer
+  still in progress far more often than it is corruption, and on a phone nothing
+  else is going to notice when it finishes. Until that was added, a mobile
+  launch that landed mid-write showed no callouts for the whole session and
+  could do nothing about it but wait for the user to restart the app.
 
 This is not hypothetical. The reporter's screenshot showed alternating conflict
 copies where every copy from one device was exactly **0 bytes**, and
@@ -264,13 +269,35 @@ thing a fresh install writes, and it runs from `onLayoutReady` — well after
 That covers the window between `onload` and the first write. `watchForLateSettings`
 covers the rest of the session, which on mobile is otherwise not covered at all:
 it listens for the app returning to the foreground — the moment a sync client has
-most likely just run — and adopts a settings file that has appeared since. Both
-launches that came up without a usable file register it, so a frozen device
-recovers on its own rather than waiting for a restart. Adopting is also the one
-automatic path to `SettingsWriter.thaw()`, and it is reached only with the real
-file in hand: the baseline then describes what is on disk, so saving is safe
-again. It stops at the first file it adopts, stays silent while there is still
-nothing there, and defers while the callout editor owns the registry.
+most likely just run — and adopts a settings file that has appeared since. Every
+launch that came up without usable settings registers it — missing, missing-on-a
+-known-device, and unreadable alike — so a frozen device recovers on its own
+rather than waiting for a restart. It stops at the first file it **adopts**,
+stays silent while there is still nothing there, and defers while the callout
+editor owns the registry.
+
+> [!IMPORTANT]
+> Seeing *our own* file on disk is not a reason to stop watching. The watcher
+> used to treat `matchesLastWrite` as "settled", and on the one path where the
+> baseline is not null — a fresh install that has written its own `data.json` —
+> that is precisely the session still waiting on a sync client. Syncthing's floor
+> is a ten-second scan delay with an hourly rescan behind it, so "nothing has
+> landed yet" is the normal state for a long time, and retiring the watcher on it
+> disarmed the only mechanism a phone has.
+
+**Adopting is what ends a freeze**, and `reloadFrom` does it as its first act, so
+both adoption paths get it — the desktop watcher and the mobile foreground check.
+It is reached only with a `loaded` read in hand: the baseline it then seeds
+describes what is on disk, so saving asserts nothing the file does not already
+say. The thaw comes **before** the hold rather than after, because
+`applySettingsRead`'s convergence flush runs inside that hold and a writer still
+frozen at that moment would drop a load-time migration on the very path that just
+recovered.
+
+Without that thaw, a session that recovered went on *looking* right — the
+callouts come back and the settings tab repaints — while every edit the user made
+from then on was discarded at the `frozen` check. On desktop that is the whole
+session after a single mid-write launch, announced by nothing.
 
 The check is deliberately **not** a `SettingsWriter` pre-write hook, which is the
 other obvious home for it. Adopting a file rebuilds the registry, a rebuild asks
@@ -281,10 +308,12 @@ that was waiting on the check. At a seam between writes there is no such knot.
 sync client mid-swap and false of a user who deleted `data.json` themselves to
 start over, and for that second user a freeze with no escape would mean every
 launch from here on silently discarding their work. So the notice announcing a
-missing file offers **Start fresh on this device**, and that button is the only
-caller of `SettingsWriter.thaw()` — see
-[`manager/settingsNotices.ts`](../src/manager/settingsNotices.ts). Nothing
-automatic reaches it.
+missing file offers **Start fresh on this device** — see
+[`manager/settingsNotices.ts`](../src/manager/settingsNotices.ts). That button
+and `reloadFrom` are the only two callers of `SettingsWriter.thaw()`, and they
+are the only two things that can answer the guess: the user saying the file is
+gone for good, or the file itself turning up. What still never happens is a thaw
+on a hunch — no timer, no retry count, no "it has probably finished by now".
 
 `tests/syncMobileWipe.test.ts` holds all of this, with the device shape the rest
 of the sync suite could not express: no `adoptExternalSettings`, startup as the

--- a/src/manager/SettingsWriter.ts
+++ b/src/manager/SettingsWriter.ts
@@ -168,15 +168,25 @@ export class SettingsWriter {
 	}
 
 	/**
-	 * Lift a {@link freeze}, on the user's explicit say-so and nothing else.
+	 * Lift a {@link freeze}, once there is a reason to believe the file again.
 	 *
 	 * A freeze is a guess — a well-founded one, but a guess — that the file it
-	 * could not find or read is coming back. When it is not coming back, because
-	 * the user deleted `data.json` themselves to start over, that guess would
-	 * otherwise stand for every launch from here on and quietly discard
-	 * everything they did next. So the notice announcing a freeze carries the way
-	 * out of it, and this is what that button calls. Nothing automatic reaches
-	 * it; that is the whole point. See `manager/settingsNotices.ts`.
+	 * could not find or read is coming back. Exactly two things answer that
+	 * guess, and both call this:
+	 *
+	 * - **The file came back.** `manager/settingsBoot.ts`'s `reloadFrom` thaws
+	 *   as its first act, because it is only ever reached with a `loaded` read
+	 *   in hand: the baseline it then seeds describes what is on disk, so saving
+	 *   asserts nothing the file does not already say. Without this a recovered
+	 *   session went on looking right while discarding every edit in it.
+	 * - **The user says it is not coming back**, because they deleted
+	 *   `data.json` themselves to start over. Left frozen, that user would have
+	 *   every launch from here on quietly throw their work away — so the notice
+	 *   announcing a freeze carries the way out, and that button calls this. See
+	 *   `manager/settingsNotices.ts`.
+	 *
+	 * What still never happens is a thaw on a *hunch* — a timer, a retry count,
+	 * or "it has probably finished by now".
 	 */
 	thaw(): void {
 		this.frozen = false;

--- a/src/manager/settingsBoot.ts
+++ b/src/manager/settingsBoot.ts
@@ -130,6 +130,12 @@ export async function loadSettingsInto(
 				"settings will not be written this session",
 		);
 		warnSettingsUnreadable();
+		// A file caught mid-write is finished moments later, and this is the
+		// only thing that will notice on a phone — Obsidian's config-folder
+		// watcher is desktop-only, so `onExternalSettingsChange` never fires
+		// there and the session would otherwise show no callouts until the user
+		// thought to restart the app.
+		watchForLateSettings(host);
 		return { isFreshInstall: false };
 	}
 
@@ -257,11 +263,23 @@ export async function adoptExternalSettings(
  * `stillFreshInstall` on a device where the file simply arrived late. Held as a
  * whole, so the rebuild publishes at most one write and never an intermediate
  * state.
+ *
+ * **Adopting is what ends a freeze.** A freeze is the guess that a file we
+ * could not read or find is coming back; arriving with that file in hand is the
+ * guess being answered, and the baseline seeded below then describes what is on
+ * disk, so saving is safe again. Without this, a session that recovered went on
+ * *looking* right — the callouts come back and repaint — while silently
+ * discarding every edit the user made for the rest of it.
+ *
+ * It thaws **before** the hold, not after: `applySettingsRead`'s convergence
+ * flush runs inside that hold, and a writer still frozen at that moment would
+ * drop the load-time migration on the very path that just recovered.
  */
 export async function reloadFrom(
 	host: ExternalReloadHost,
 	read: Extract<SettingsRead, { kind: "loaded" }>,
 ): Promise<void> {
+	host.settingsWriter.thaw();
 	await host.settingsWriter.hold(async () => {
 		await applySettingsRead(host, read);
 		host.resyncThemeRows();

--- a/src/manager/settingsLateArrival.ts
+++ b/src/manager/settingsLateArrival.ts
@@ -75,10 +75,11 @@ export async function stillFreshInstall(
  * Keep looking for a `data.json` that startup did not find, and adopt it the
  * moment it lands.
  *
- * Registered by `loadSettingsInto` for both launches that came up without a
- * usable settings file — the frozen one, where a device that has run here
- * before found its file missing, and the fresh-install one, where the file may
- * simply not have arrived yet.
+ * Registered by `loadSettingsInto` for every launch that came up without usable
+ * settings: the frozen one, where a device that has run here before found its
+ * file missing; the fresh-install one, where the file may simply not have
+ * arrived yet; and the one that found a file it could not read, which is a
+ * transfer still in progress far more often than it is corruption.
  *
  * `stillFreshInstall` covers the narrow window between `onload` and the first
  * write. This covers the rest of the session, which on mobile is otherwise
@@ -90,11 +91,12 @@ export async function stillFreshInstall(
  * most likely just run. It is a single small read, and it stops at the first
  * file it manages to adopt.
  *
- * **Adopting also thaws the writer.** A freeze is the guess that the missing
- * file is coming back; when it does come back there is nothing left to guess
- * about, and the baseline now describes the file on disk, so the session can
- * safely save again. That is the one automatic path to `thaw()`, and it is
- * reached only with the real file in hand — never on a hunch.
+ * **Adopting also thaws the writer**, in `reloadFrom`. A freeze is the guess
+ * that the missing file is coming back; when it does come back there is nothing
+ * left to guess about, and the baseline now describes the file on disk, so the
+ * session can safely save again. Every automatic path to `thaw()` runs through
+ * an adoption, and an adoption is reached only with the real file in hand —
+ * never on a hunch.
  */
 export function watchForLateSettings(host: ExternalReloadHost): void {
 	// Absent on a test harness, and on any host that is not a real plugin.
@@ -116,18 +118,21 @@ export function watchForLateSettings(host: ExternalReloadHost): void {
 		// said here would be said hundreds of times.
 		if (read.kind !== "loaded") return;
 
-		// Our own writing, which means this session was never waiting.
-		if (host.settingsWriter.matchesLastWrite(read.json)) {
-			settled = true;
-			return;
-		}
+		// Our own writing. Nothing has landed *yet* — which is not the same as
+		// nothing landing, so this must not retire the watcher. A fresh install
+		// that created its own file is exactly the session still waiting on a
+		// sync client, and Syncthing's floor is a ten-second scan delay with an
+		// hourly rescan behind it. Marking this settled disarmed the only
+		// mechanism a phone has, on the one path where it was still needed.
+		if (host.settingsWriter.matchesLastWrite(read.json)) return;
 
 		// The editor owns the registry right now; rebuilding under it would
 		// change the row being edited. Try again next time.
 		if (host.pruneSuspended || host.registry.hasPreviewDefinition()) return;
 
 		settled = true;
-		host.settingsWriter.thaw();
+		// `reloadFrom` thaws — see its docblock. Adopting is the one thing that
+		// ends a freeze, and it is reached only with the real file in hand.
 		await reloadFrom(host, read);
 	}
 }

--- a/tests/syncMobileWipe.test.ts
+++ b/tests/syncMobileWipe.test.ts
@@ -328,6 +328,58 @@ describe("a data.json that turns up after startup", () => {
 		assert.ok(p.registry.get("insight"), "the real settings were not adopted");
 	});
 
+	it("keeps watching after a file it could not read", async () => {
+		// The other half of the freeze. A phone has no config-folder watcher, so
+		// if the foreground listener is not registered here, a launch that
+		// landed mid-write shows no callouts and can do nothing about it until
+		// the user thinks to restart the app.
+		storage.clear();
+		const disk = new Disk();
+		disk.content = '{"version":4,"callouts":[{"id":"tru';
+		const p = phone("new-phone", disk);
+		await p.boot();
+		assert.strictEqual(p.watching(), true, "nothing was left watching");
+
+		disk.content = vaultWithUserCallouts().content;
+		await p.returnToApp();
+		assert.ok(p.registry.get("insight"), "the repaired file was not adopted");
+
+		// The content, not the write count: an adoption that wrote something of
+		// its own would satisfy a bare `writes > 0` while the user's edit was
+		// still being thrown away.
+		p.registry.add(authored("made-after-recovery"));
+		await p.save();
+		assert.ok(
+			(disk.content ?? "").includes("made-after-recovery"),
+			"stayed read-only for the whole session",
+		);
+	});
+
+	it("goes on watching after seeing a file it wrote itself", async () => {
+		// Our own bytes on disk say only that nothing has landed *yet*. Treating
+		// that as "settled" retires the one mechanism a phone has, and the file
+		// this device is waiting for is usually still in flight.
+		storage.clear();
+		const disk = new Disk();
+		const p = phone("new-phone", disk);
+		await p.boot();
+
+		p.registry.add(authored("first-one"));
+		await p.save();
+		assert.ok(disk.writes > 0, "a real fresh install was blocked");
+
+		// A foreground where the only thing on disk is what we just wrote.
+		await p.returnToApp();
+
+		// The vault's real settings finally reach the phone.
+		disk.content = vaultWithUserCallouts().content;
+		await p.returnToApp();
+		assert.ok(
+			p.registry.get("insight"),
+			"stopped watching after seeing its own file",
+		);
+	});
+
 	it("goes on writing when nothing turned up after all", async () => {
 		storage.clear();
 		const disk = new Disk();

--- a/tests/syncPingPong.test.ts
+++ b/tests/syncPingPong.test.ts
@@ -373,6 +373,37 @@ describe("a data.json that cannot be read", () => {
 		assert.strictEqual(disk.content, "}} not json {{", "the file changed");
 	});
 
+	it("writes again once the real file turns up and is adopted", async () => {
+		// The freeze above is a guess that the file is coming back. When it does
+		// come back and is adopted, the guess has been answered: the baseline
+		// now describes what is on disk, so there is nothing left to protect.
+		// Without this the user watches their callouts reappear and then every
+		// edit they make is discarded in silence, for the rest of the session.
+		storage.clear();
+		const disk = new Disk();
+		disk.content = "}} not json {{";
+		const a = device("A", disk);
+		await a.boot();
+		assert.strictEqual(disk.writesBy("A"), 0);
+
+		const seed = new CalloutRegistry();
+		seed.load(null);
+		seed.add(authored("insight"));
+		disk.content = JSON.stringify(seed.toSaveData(), undefined, 2);
+		await a.adopt();
+		assert.ok(a.registry.get("insight"), "the repaired file was not adopted");
+
+		// The content, not the write count: an adoption that wrote something of
+		// its own would satisfy a bare `writes > 0` while the user's edit was
+		// still being thrown away.
+		a.registry.add(authored("made-after-recovery"));
+		await a.save();
+		assert.ok(
+			(disk.content ?? "").includes("made-after-recovery"),
+			"stayed read-only after recovering the file",
+		);
+	});
+
 	it("still treats a genuinely missing file as a fresh install", async () => {
 		storage.clear();
 		const disk = new Disk();

--- a/user-guide/08-fallback-callouts-and-auto-discovery.md
+++ b/user-guide/08-fallback-callouts-and-auto-discovery.md
@@ -42,9 +42,9 @@ In practice this means:
 - A brand-new device — or one where you have cleared Obsidian's local data — scans the vault once to build that list, the same way a fresh install does.
 
 - When settings arrive from your other device, Callout Studio adopts them without writing anything back. Two devices that agree stay silent, so there is nothing for a sync tool to reconcile and no conflict copies to clean up.
-- If your settings file is ever half-written or unreadable — a sync still in progress, most likely — Callout Studio leaves it completely alone rather than replacing it. Your callouts may be missing until you reload Obsidian, and it will tell you so, but the file itself is never overwritten with an empty one.
+- If your settings file is ever half-written or unreadable — a sync still in progress, most likely — Callout Studio leaves it completely alone rather than replacing it. Your callouts may be missing for a moment, and it will tell you so, but the file itself is never overwritten with an empty one.
 
-On desktop, Callout Studio also notices when your settings file is updated by a sync tool while Obsidian is open, and picks up the change without you having to restart. On mobile, Obsidian gives plugins no way to be told about that, so reopening the vault is still the way to pick up settings that arrived while it was open.
+On desktop, Callout Studio notices when your settings file is updated by a sync tool while Obsidian is open, and picks up the change without you having to restart. Obsidian gives plugins no way to be told about that on mobile, so there Callout Studio checks each time you come back to the app — which is usually just after your sync tool has run. Either way, once your real settings turn up they are adopted and everything works normally again, including saving: you do not have to restart, and any callout you make after that point is kept.
 
 ---
 **Next:** [Deleting and replacing callouts](09-deleting-and-replacing-callouts.md)

--- a/user-guide/13-resetting-callouts-and-settings.md
+++ b/user-guide/13-resetting-callouts-and-settings.md
@@ -48,9 +48,9 @@ Everything above is a reset you asked for. This section is about the one you did
 
 Callout Studio keeps your callout types in a single settings file inside your vault. If you sync your vault, that file travels like any other - and a sync client can be caught mid-delivery, with the file briefly missing or only half-written. A phone is the most common place to notice, because it often opens a vault while the sync is still catching up.
 
-When Callout Studio starts and finds its settings file missing or unreadable, it does **not** treat that as an empty setup. It shows a notice, leaves the file completely alone, and writes nothing at all for the rest of that session. Your callout types will be missing from the list while that notice is up, but the file on disk still has them.
+When Callout Studio starts and finds its settings file missing or unreadable, it does **not** treat that as an empty setup. It shows a notice, leaves the file completely alone, and stops writing. Your callout types will be missing from the list while that notice is up, but the file on disk still has them.
 
-**What to do:** let the sync finish, then reload Obsidian. That's usually all it takes.
+**What to do:** let the sync finish. Callout Studio keeps watching for the file, and picks it up on its own the moment it lands — on desktop as soon as it changes, on mobile the next time you come back to the app. Your callout types reappear and saving starts working again, so anything you change from then on is kept. Reloading Obsidian also works and is never wrong, but it is usually not needed.
 
 The one case where the file really is gone for good is when you deleted it yourself to start over. For that, the notice offers **Start fresh on this device**, which lets Callout Studio save again from that point on. Only use it if you know the file isn't coming back - once Callout Studio starts writing, it writes what it currently has, which is the built-in callout types and nothing else.
 


### PR DESCRIPTION

Two bugs that both end in silent data loss. Neither was on the issue list; both were found while tracing #53.

### A recovered session stayed read-only forever

A desktop session that boots on an unreadable `data.json` freezes the writer. Later `onExternalSettingsChange` fires, `adoptExternalSettings` reads a now-good file, and `reloadFrom` rebuilds the registry and repaints — but **nothing called `thaw()`**. The only two call sites were the "Start fresh" notice link and the mobile foreground watcher.

So the user watched their callouts come back, carried on working, and every edit was discarded at the `frozen` check for the rest of the session, announced by nothing.

`reloadFrom` now thaws as its first act, which covers both adoption paths. It has to be **before** the hold: `applySettingsRead`'s convergence flush runs inside that hold, and a writer still frozen there would drop a load-time migration on the very path that just recovered.

### A phone that booted on a half-written file never looked again

- `watchForLateSettings` was registered on both `absent` branches but **not** on `unreadable`. Obsidian's config-folder watcher is desktop-only, so a phone that opened mid-transfer showed no callouts for the whole session with no recovery but a restart. It is registered there now.
- `adoptIfArrived` treated `matchesLastWrite` as "settled" and retired the watcher. Seeing *our own* bytes on disk says only that nothing has landed **yet** — and on the one path where that baseline is non-null (a fresh install that wrote its own file) that is exactly the session still waiting on a sync client. Syncthing's floor is a ten-second scan delay with an hourly rescan behind it. It is a plain `return` now; `settled` is set only by a real adoption.

### Tests

Three new regression tests, each verified to **fail on the pre-fix code** first:

- `syncPingPong` — boot unreadable, adopt a repaired file, then assert the user's next edit reaches disk *by content*, not by write count (a bare `writes > 0` would pass on an adoption that wrote something of its own).
- `syncMobileWipe` — the unreadable boot registers a watcher, adopts on foreground, and can save afterwards.
- `syncMobileWipe` — a foreground that sees our own file still adopts a different one later.

`npm test` 4640 pass / 1 fail; `npx tsc -noEmit` and `npm run lint` clean. The one failure is `main.js stays inside its budget`, which fails identically on unmodified `master` (4637/1) — the local `main.js` is an 8.7 MB `npm run dev` build, and it is gitignored.

### Docs

`internals-docs/07-persistence-and-caching.md` had three claims this makes false, including "that button is the only caller of `thaw()`" — already false since b3f037f. Also `user-guide/08` (said mobile needs a reopen; the foreground watcher has handled that since b3f037f) and `user-guide/13`.