### PR TITLE
Freeze a fresh install until its folder is confirmed

### DIFF
--- a/internals-docs/03-plugin-lifecycle.md
+++ b/internals-docs/03-plugin-lifecycle.md
@@ -38,7 +38,7 @@ specifically *because* of what runs before or after them.
 28. new CalloutStudioAPI(this)
 29. void icons.initialize()                                          ← background, non-blocking
 30. void ensureLocale()                                              ← background, non-blocking
-31. workspace.onLayoutReady: maybeShowWelcomeOnLaunch, then first-run discovery or scheduled prune,
+31. workspace.onLayoutReady: runLaunchSequence — confirmFreshInstall, then welcome, then first-run discovery or scheduled prune,
     then registerIncrementalWatchers()
 ```
 
@@ -188,24 +188,36 @@ decide which of the five fixed commands to actually call `addCommand` for.
 `this.registry.settings` — there is no separate settings object on the plugin
 itself.
 
-### Step 31: welcome, then first-run discovery, then incremental watchers — in that exact order, deferred to layout-ready
+### Step 31: confirm the fresh install, welcome, then first-run discovery — in that exact order, deferred to layout-ready
+
+`main.ts` only schedules it; the three steps and the rule about their order live
+in [`manager/launchSequence.ts`](../src/manager/launchSequence.ts).
 
 ```ts
-this.app.workspace.onLayoutReady(async () => {
+export async function runLaunchSequence(plugin, boot) {
     try {
-        await this.maybeShowWelcomeOnLaunch(isFreshInstall);
-        if (!this.settings.firstRunCompleted) {
-            await this.runFirstRunDiscovery();
+        const freshInstall = boot.isFreshInstall
+            ? await confirmFreshInstall(plugin)
+            : false;
+        await maybeShowWelcomeOnLaunch(plugin, freshInstall);
+        if (!plugin.localState.firstRunCompleted) {
+            await runFirstRunDiscovery(plugin);
         } else {
-            this.discovery.schedulePrune(2000);
+            plugin.discovery.schedulePrune(PRUNE_AFTER_LAUNCH_MS);
         }
     } finally {
-        this.discovery.registerIncrementalWatchers();
+        plugin.discovery.registerIncrementalWatchers();
     }
-});
+}
 ```
 
-- **Welcome first**, so it never stacks visually on top of the first-run scan
+- **The confirmation first**, because a launch that found no `data.json` has been
+  frozen since `onload` and cannot write until this answers whether it is a
+  brand-new device or one a synced vault is still reaching. `maybeShowWelcomeOnLaunch`
+  takes that answer as an argument and re-reads nothing itself — see
+  [Persistence § A file that is not there yet](07-persistence-and-caching.md#a-file-that-is-not-there-yet)
+  for why the guard has to sit here rather than around the write.
+- **Welcome next**, so it never stacks visually on top of the first-run scan
   consent modal (which only large vaults see).
 - **`firstRunCompleted` is only persisted after the chosen path finishes** — a
   crash or reload mid-scan safely re-runs the whole first-run flow on the next

--- a/internals-docs/07-persistence-and-caching.md
+++ b/internals-docs/07-persistence-and-caching.md
@@ -259,14 +259,46 @@ available at the moment of the read:
 - **Time.** A first launch has no index either, so nothing at load time can rule
   out a device the vault has only just reached. What rules it out is looking
   again later: [`manager/settingsLateArrival.ts`](../src/manager/settingsLateArrival.ts)
-  re-reads at the last moment before a file would be created, and adopts one that
-  has turned up instead of replacing it.
+  re-reads once the workspace is ready, and adopts a file that has turned up
+  instead of replacing it.
 
-That moment is `settings/welcomeRouting.ts`. The `welcomeSeen` flag is the first
-thing a fresh install writes, and it runs from `onLayoutReady` — well after
-`onload`, which is time a sync client can use.
+So the session **writes nothing until that second look**. `loadSettingsInto`
+freezes the writer on this branch too, and `confirmFreshInstall` — called from
+[`manager/launchSequence.ts`](../src/manager/launchSequence.ts) at
+`onLayoutReady` — ends the freeze one way or the other: `thaw()` if the folder is
+still empty, or an adoption if the file arrived. The welcome screen then creates
+`data.json` exactly as it always has, and `maybeShowWelcomeOnLaunch` takes the
+answer as an argument rather than re-reading anything itself.
 
-That covers the window between `onload` and the first write. `watchForLateSettings`
+> [!IMPORTANT]
+> The freeze is the point, and guarding the *creating write* instead is what
+> shipped in 2.12.1 and left #53 open. `welcomeSeen` is the first write a fresh
+> install makes, so re-checking there looks sufficient — but it is not the only
+> write that can happen first. `void icons.initialize()` and any `css-change`
+> theme sweep reach `saveSettings` on their own schedule, unordered against
+> `onLayoutReady`, and on this branch `SaveGuard`'s baseline is still `null`, so
+> nothing suppresses them. Whichever fires first publishes the shipped defaults,
+> and the sync client carries that to every other device.
+>
+> A pre-write check inside `SettingsWriter` is the obvious repair and it
+> **deadlocks**. `runPass` is what `inFlight` holds; a check that adopts calls
+> `reloadFrom`, whose `hold()` releases with `await this.save()`, and that
+> `save()` — seeing `inFlight` set — returns a `followUp` chained on the very
+> `runPass` awaiting it. A closed promise cycle, on exactly the path the check
+> exists for. `frozen` is the only writer-level gate that is safe here, because
+> it is a synchronous boolean read at the top of `save()`: a re-entrant save
+> resolves immediately instead of joining a promise the gate is awaiting.
+>
+> Nothing is lost by suppressing rather than deferring — `runPass` builds its
+> payload at write time, so anything mutated during the freeze rides the first
+> write after it.
+
+There is one asymmetry worth keeping in mind: `confirmFreshInstall` must be
+called **only** for this freeze. The `absent && hasIndex` freeze reports "still
+nothing there" too, and thawing it would write the built-ins over settings that
+have merely gone missing.
+
+`watchForLateSettings`
 covers the rest of the session, which on mobile is otherwise not covered at all:
 it listens for the app returning to the foreground — the moment a sync client has
 most likely just run — and adopts a settings file that has appeared since. Every
@@ -299,10 +331,11 @@ callouts come back and the settings tab repaints — while every edit the user m
 from then on was discarded at the `frozen` check. On desktop that is the whole
 session after a single mid-write launch, announced by nothing.
 
-The check is deliberately **not** a `SettingsWriter` pre-write hook, which is the
-other obvious home for it. Adopting a file rebuilds the registry, a rebuild asks
-for saves of its own, and those saves would then queue behind the very write pass
-that was waiting on the check. At a seam between writes there is no such knot.
+Neither check is a `SettingsWriter` pre-write hook, which is the other obvious
+home for both — see the deadlock above. Adopting a file rebuilds the registry, a
+rebuild asks for saves of its own, and those saves do not merely *queue* behind
+the write pass waiting on the check: `hold()` awaits its own release, so they
+close a cycle with it. At a seam between writes there is no such knot.
 
 **The freeze carries its own way out.** "The file is coming back" is true of a
 sync client mid-swap and false of a user who deleted `data.json` themselves to

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,10 +30,9 @@ import {
 } from "./manager/settingsBoot";
 import { registerThemeRowSync } from "./manager/theme/themeRowSync";
 import { removeLegacyStartupSnippet } from "./manager/legacyStartupSnippet";
-import { runFirstRunDiscovery } from "./manager/firstRunDiscovery";
+import { runLaunchSequence } from "./manager/launchSequence";
 import { CalloutStudioSettingsTab } from "./settings/SettingsTab";
 import { WelcomeModal } from "./settings/WelcomeModal";
-import { maybeShowWelcomeOnLaunch } from "./settings/welcomeRouting";
 import { CalloutEditor } from "./settings/CalloutEditor";
 import { QuickInsertModal } from "./settings/QuickInsertModal";
 import { CalloutAutoComplete } from "./editor/AutoComplete";
@@ -79,7 +78,12 @@ export default class CalloutStudioPlugin extends Plugin {
 	icons!: IconService;
 	locales!: LocaleStore;
 	settingsTab!: CalloutStudioSettingsTab;
-	private discovery!: CalloutDiscovery;
+	/**
+	 * Public for the same reason `localState` is: `manager/launchSequence.ts`
+	 * drives the post-layout half of startup and needs the prune and the
+	 * incremental watchers.
+	 */
+	discovery!: CalloutDiscovery;
 	settingsWriter!: SettingsWriter;
 	/**
 	 * Discovery's index and the rest of what must not travel between devices.
@@ -351,24 +355,11 @@ export default class CalloutStudioPlugin extends Plugin {
 		// the next launch tries again.
 		void this.ensureLocale();
 
-		// First-run vault discovery — once per DEVICE, which is also how a
-		// machine whose local index is missing rebuilds it. Decoupled from
-		// first render so onload stays fast; see manager/firstRunDiscovery.ts
-		// for the size threshold and the consent modal. Afterwards we only
-		// prune rows a previous session left orphaned.
-		this.app.workspace.onLayoutReady(async () => {
-			try {
-				// Welcome first, so it never stacks on top of the first-run
-				// scan modal (which only appears for large vaults).
-				await maybeShowWelcomeOnLaunch(this, boot.isFreshInstall);
-				if (!this.localState.firstRunCompleted) {
-					await runFirstRunDiscovery(this);
-				} else {
-					this.discovery.schedulePrune(2000);
-				}
-			} finally {
-				this.discovery.registerIncrementalWatchers();
-			}
+		// Confirm the fresh install, greet, then run first-run discovery —
+		// decoupled from first render so onload stays fast. See
+		// manager/launchSequence.ts for why those three are one function.
+		this.app.workspace.onLayoutReady(() => {
+			void runLaunchSequence(this, boot);
 		});
 	}
 

--- a/src/manager/SettingsWriter.ts
+++ b/src/manager/SettingsWriter.ts
@@ -154,14 +154,32 @@ export class SettingsWriter {
 	}
 
 	/**
-	 * Stop writing `data.json` for the rest of the session.
+	 * Stop writing `data.json` until something lifts it. Three callers, and the
+	 * third is not like the other two:
 	 *
-	 * For the one case where the file exists but could not be read: the
-	 * in-memory registry is then built from nothing and describes none of the
-	 * user's callouts, so every save it could produce would replace a file we
-	 * failed to understand with one we know to be wrong. There is no recovering
-	 * from that, and no undo — so the session goes read-only and the user is
-	 * told to reload. See `manager/settingsFile.ts`.
+	 * - **The file exists but could not be read.** The in-memory registry is
+	 *   then built from nothing and describes none of the user's callouts, so
+	 *   every save it could produce would replace a file we failed to understand
+	 *   with one we know to be wrong. See `manager/settingsFile.ts`.
+	 * - **The file is missing on a device that has run here before.** Its
+	 *   settings have gone away since it last launched — a sync client mid-swap,
+	 *   most often — and the built-ins must not be written over whatever took
+	 *   them.
+	 * - **The file is missing on a device that has never run here.** This one is
+	 *   *provisional* and lasts under a second: it holds the whole window
+	 *   between `onload` and `onLayoutReady`, where nothing has yet looked at
+	 *   the folder a second time and a brand-new device cannot be told apart
+	 *   from one a synced vault is still reaching. `confirmFreshInstall` ends it
+	 *   either way — {@link thaw} if the folder is still empty, or an adoption
+	 *   if the file turned up. Nothing announces it, because in the overwhelming
+	 *   majority of launches there is nothing to announce.
+	 *
+	 * The first two are read-only for the session unless the user or the file
+	 * itself says otherwise; see {@link thaw}.
+	 *
+	 * Nothing is lost by suppressing rather than deferring: `runPass` builds its
+	 * payload at write time, so whatever was mutated during a freeze is carried
+	 * by the first write after it.
 	 */
 	freeze(): void {
 		this.frozen = true;
@@ -195,6 +213,17 @@ export class SettingsWriter {
 	/** Whether a save is currently in flight or queued behind one. */
 	get busy(): boolean {
 		return this.inFlight !== null || this.queued;
+	}
+
+	/**
+	 * Whether {@link freeze} is in effect.
+	 *
+	 * Read by `confirmFreshInstall`, which must not re-read `data.json` or greet
+	 * a user whose file has already been adopted — an adoption thaws, so a
+	 * writer that is no longer frozen is the record of one having happened.
+	 */
+	get isFrozen(): boolean {
+		return this.frozen;
 	}
 
 	private async runPass(): Promise<void> {

--- a/src/manager/launchSequence.ts
+++ b/src/manager/launchSequence.ts
@@ -1,0 +1,68 @@
+/**
+ * manager/launchSequence.ts — what happens once the workspace is ready, in the
+ * order it has to happen in.
+ *
+ * Three steps that look unrelated and are not, which is why they are one
+ * function rather than three `onLayoutReady` callbacks:
+ *
+ * 1. **Settle whether this is a fresh install.** A launch that found no
+ *    `data.json` has been frozen since `onload` — nothing at that moment
+ *    separates a brand-new device from one a synced vault is still reaching, so
+ *    the session writes nothing until the question is asked again here. This is
+ *    the latest it can be left open without a genuine fresh install noticing,
+ *    and answering it is what lets the session write at all.
+ * 2. **The welcome screen**, which is the first thing a fresh install writes.
+ *    It runs before first-run discovery so it never stacks on top of the
+ *    large-vault consent modal.
+ * 3. **First-run vault discovery**, once per *device* — which is also how a
+ *    machine whose local index is missing rebuilds it. Afterwards there is only
+ *    the prune of rows a previous session left orphaned.
+ *
+ * The ordering between 1 and 2 is the load-bearing one: `maybeShowWelcomeOnLaunch`
+ * takes the answer as an argument and no longer re-reads anything itself, so a
+ * caller that skipped the confirmation would greet a user whose vault is
+ * already full of callouts *and* write the shipped defaults over the settings
+ * that were arriving. That was issue #53.
+ *
+ * Lives here rather than in `main.ts` for the reason everything else does: that
+ * file is lifecycle wiring, and this is a policy about three steps.
+ */
+import { runFirstRunDiscovery } from "./firstRunDiscovery";
+import { confirmFreshInstall } from "./settingsLateArrival";
+import { maybeShowWelcomeOnLaunch } from "../settings/welcomeRouting";
+import type { SettingsBootResult } from "./settingsBoot";
+import type CalloutStudioPlugin from "../main";
+
+/** How long a launch waits before pruning rows an earlier session orphaned. */
+const PRUNE_AFTER_LAUNCH_MS = 2000;
+
+/**
+ * Run the post-layout half of startup.
+ *
+ * The incremental discovery watchers are registered in a `finally`, so a step
+ * that throws — a modal the user dismissed oddly, a read that failed — costs
+ * that step and not the rest of the session's discovery.
+ */
+export async function runLaunchSequence(
+	plugin: CalloutStudioPlugin,
+	boot: SettingsBootResult,
+): Promise<void> {
+	try {
+		// Only for the fresh-install freeze. The other one — a file missing on
+		// a device that has run here before — must not be lifted by this; see
+		// `confirmFreshInstall`'s warning.
+		const freshInstall = boot.isFreshInstall
+			? await confirmFreshInstall(plugin)
+			: false;
+
+		await maybeShowWelcomeOnLaunch(plugin, freshInstall);
+
+		if (!plugin.localState.firstRunCompleted) {
+			await runFirstRunDiscovery(plugin);
+		} else {
+			plugin.discovery.schedulePrune(PRUNE_AFTER_LAUNCH_MS);
+		}
+	} finally {
+		plugin.discovery.registerIncrementalWatchers();
+	}
+}

--- a/src/manager/settingsBoot.ts
+++ b/src/manager/settingsBoot.ts
@@ -167,10 +167,16 @@ export async function loadSettingsInto(
 	// first launch must be free to write, or the user's first callout is never
 	// saved. It may equally be a device this vault has only just reached, whose
 	// `data.json` is still in flight, and nothing available *now* separates the
-	// two. What separates them is time: see `manager/settingsLateArrival.ts`,
-	// which asks again at the last moment before a file would be created, and
-	// keeps watching for the rest of the session.
-	if (read.kind === "absent") watchForLateSettings(host);
+	// two. What separates them is time, so the session is frozen *provisionally*
+	// and `confirmFreshInstall` ends it at `onLayoutReady`. Guarding only the
+	// write that creates the file is what shipped and why #53 stayed open: a
+	// background icon fetch or a theme sweep reaches `saveSettings` unordered
+	// against it and publishes the defaults first. A freeze is the only gate
+	// that catches all of them — see internals-docs/07.
+	if (read.kind === "absent") {
+		host.settingsWriter.freeze();
+		watchForLateSettings(host);
+	}
 	await applySettingsRead(host, read);
 	return { isFreshInstall: read.kind === "absent" };
 }

--- a/src/manager/settingsLateArrival.ts
+++ b/src/manager/settingsLateArrival.ts
@@ -72,6 +72,65 @@ export async function stillFreshInstall(
 }
 
 /**
+ * End the provisional freeze a fresh-install launch started with, and answer
+ * whether this really is a fresh install.
+ *
+ * `loadSettingsInto` cannot tell a brand-new device from one a synced vault is
+ * still reaching — both read as `absent`, and a first launch has no device index
+ * to break the tie either. It resolves that by writing nothing at all until this
+ * runs, at `onLayoutReady`, which is as long as the question can be left open
+ * without a genuine fresh install noticing.
+ *
+ * Three outcomes, and only the first lets the session write:
+ *
+ * - **Still nothing there.** A real fresh install. Thaw, and let the welcome
+ *   screen create the file exactly as it always has.
+ * - **A file turned up.** `stillFreshInstall` adopts it through `reloadFrom`,
+ *   which thaws on its own because it arrived holding the real settings.
+ * - **A file turned up and cannot be read.** Stay frozen, and say so.
+ *
+ * Returns `false` without reading anything when the writer is no longer frozen,
+ * which means a file was already adopted between `onload` and here — by the
+ * foreground watcher, or on desktop by `onExternalSettingsChange`. That session
+ * has its settings, so there is nothing to confirm and nobody to greet.
+ *
+ * > [!WARNING]
+ * > Call this **only** for a launch whose boot reported `isFreshInstall`. The
+ * > other freeze that reaches `onLayoutReady` — a file missing on a device that
+ * > has run here before — looks identical from inside this function, and
+ * > "still nothing there" is exactly what that device reports. Thawing it would
+ * > write the built-ins over settings that have merely gone missing, which is
+ * > the whole of what `loadSettingsInto`'s `hasIndex` test exists to prevent.
+ */
+export async function confirmFreshInstall(
+	host: ExternalReloadHost,
+): Promise<boolean> {
+	if (!host.settingsWriter.isFrozen) return false;
+
+	let stillFresh: boolean;
+	try {
+		stillFresh = await stillFreshInstall(host);
+	} catch (err) {
+		// Genuinely exceptional: `readSettingsFile` already turns an adapter
+		// that will not answer into `unreadable` rather than throwing. But the
+		// freeze this releases has no other way out, so a throw here would
+		// leave a fresh install keeping nothing — this launch and, since no
+		// file ever gets created, every launch after it. Between "might
+		// overwrite a file that is probably not there" and "certainly discards
+		// everything the user does", the first is the better bet.
+		console.error(
+			"[callout-studio] could not confirm a fresh install; " +
+				"allowing this session to write",
+			err,
+		);
+		stillFresh = true;
+	}
+
+	if (stillFresh) host.settingsWriter.thaw();
+	return stillFresh;
+}
+
+/**
  * Keep looking for a `data.json` that startup did not find, and adopt it the
  * moment it lands.
  *

--- a/src/settings/welcomeRouting.ts
+++ b/src/settings/welcomeRouting.ts
@@ -10,15 +10,17 @@
  *   in `onload`, from the data that was just loaded.
  * - **The flag is persisted before the modal opens**, so a startup interrupted
  *   while the screen is up (a crash, a reload) does not show it again on the
- *   next launch. That write is also the first one a fresh install makes, which
- *   is why the second look for a late-arriving `data.json` belongs here — see
- *   `manager/settingsBoot.ts`'s `stillFreshInstall`.
+ *   next launch. That write is also the first one a fresh install makes — and
+ *   it is safe to make here only because `isFreshInstall` now arrives already
+ *   confirmed. `manager/settingsLateArrival.ts`'s `confirmFreshInstall` has
+ *   re-read the folder immediately before this runs, and the session was frozen
+ *   until it did; this file used to make that check itself, which guarded this
+ *   one write while every background save went around it. Issue #53.
  *
  * `openWelcome()` on the plugin is the deliberate bypass — the protocol handler
  * and the DevTools console reach the screen through it regardless of the flag.
  */
 import { WelcomeModal } from "./WelcomeModal";
-import { stillFreshInstall } from "../manager/settingsLateArrival";
 import type { ExternalReloadHost } from "../manager/settingsBoot";
 import type { SettingsTabPlugin } from "./sections/types";
 
@@ -31,19 +33,15 @@ type WelcomeHost = SettingsTabPlugin &
 /**
  * Show the welcome screen if this launch is the one that should show it.
  *
- * Awaited by `onLayoutReady` before first-run discovery, so the splash never
- * stacks on top of the large-vault scan modal.
+ * `isFreshInstall` arrives already confirmed — `manager/launchSequence.ts` asks
+ * `confirmFreshInstall` immediately before this, and awaits this before
+ * first-run discovery so the splash never stacks on the large-vault scan modal.
  */
 export async function maybeShowWelcomeOnLaunch(
 	plugin: WelcomeHost,
 	isFreshInstall: boolean,
 ): Promise<void> {
 	if (plugin.settings.welcomeSeen || !isFreshInstall) return;
-	// Startup found no settings file, and this is the moment we would create
-	// one. On a device a synced vault has only just reached, that file may have
-	// arrived in the meantime — writing here would replace it with the shipped
-	// defaults and sync that back over every other device. Issue #53.
-	if (!(await stillFreshInstall(plugin))) return;
 	plugin.settings.welcomeSeen = true;
 	await plugin.saveSettings();
 	await new WelcomeModal(plugin).prompt();

--- a/tests/repoSourceRules.test.ts
+++ b/tests/repoSourceRules.test.ts
@@ -846,7 +846,11 @@ describe("no new oversized files", () => {
 		// back into a live registry to manager/settingsBoot.ts, and the two
 		// repaint passes to editor/renderRefresh.ts. What is left is lifecycle
 		// and wiring, which is all CLAUDE.md asks of this file.
-		"src/main.ts": 512,
+		// Lowered again from 512: the post-layout half of startup — confirm the
+		// fresh install, greet, run first-run discovery — moved to
+		// manager/launchSequence.ts, which is where the ordering rule between
+		// those three belongs.
+		"src/main.ts": 503,
 		"src/icons/renderIcon.ts": 547,
 		// Lowered from 528: `STYLE_DEMO_ID` moved to constants.ts, where the
 		// discovery/import/autocomplete filters that now consult it can reach

--- a/tests/syncMobileWipe.test.ts
+++ b/tests/syncMobileWipe.test.ts
@@ -32,7 +32,7 @@ import { DeviceLocalStore } from "../src/manager/DeviceLocalStore";
 import { SettingsWriter } from "../src/manager/SettingsWriter";
 import { loadSettingsInto } from "../src/manager/settingsBoot";
 import type { ExternalReloadHost } from "../src/manager/settingsBoot";
-import { stillFreshInstall } from "../src/manager/settingsLateArrival";
+import { confirmFreshInstall } from "../src/manager/settingsLateArrival";
 import { maybeShowWelcomeOnLaunch } from "../src/settings/welcomeRouting";
 import type { CalloutDefinition } from "../src/types";
 import { installFakeDom } from "./support/fakeDom";
@@ -139,6 +139,14 @@ function phone(name: string, disk: Disk) {
 		host,
 		writer,
 		boot: () => loadSettingsInto(host),
+		/**
+		 * `main.ts`'s `onLayoutReady`, where a launch that found no settings
+		 * file settles whether it really is a fresh install. Until it runs that
+		 * launch is frozen and writes nothing, so the window between the two is
+		 * where issue #53 lives — and a harness that goes straight from `boot()`
+		 * to the welcome cannot see it.
+		 */
+		layoutReady: () => confirmFreshInstall(host),
 		save: () => writer.save(),
 		/** The user switches back to Obsidian. */
 		returnToApp: async () => {
@@ -223,6 +231,7 @@ describe("a phone whose data.json has not arrived", () => {
 
 		const boot = await p.boot();
 		assert.strictEqual(boot.isFreshInstall, true);
+		assert.strictEqual(await p.layoutReady(), true, "was not let through");
 
 		p.registry.add(authored("first-one"));
 		await p.save();
@@ -230,6 +239,51 @@ describe("a phone whose data.json has not arrived", () => {
 		assert.ok(
 			(disk.content ?? "").includes("first-one"),
 			"the callout did not reach the file",
+		);
+	});
+
+	it("writes nothing before the launch has confirmed it is fresh", async () => {
+		// The window issue #53 actually lives in, and the one the welcome-time
+		// re-check could never see. `void icons.initialize()` runs unordered
+		// against `onLayoutReady`, and `IconFetchManager` saves the moment it
+		// has artwork — so a background write can create `data.json` from the
+		// shipped defaults before anything has looked at the folder a second
+		// time. A theme sweep reaching `registry.onChange` does the same.
+		storage.clear();
+		const disk = new Disk();
+		const p = phone("new-phone", disk);
+		await p.boot();
+
+		await p.save();
+		assert.strictEqual(disk.writes, 0, "a background save created the file");
+		assert.strictEqual(disk.content, null, "the file exists too early");
+	});
+
+	it("leaves the next launch of a confirmed fresh install alone", async () => {
+		// The other direction of the freeze, and the reason the welcome screen's
+		// write is load bearing rather than ceremony. A launch that confirms it
+		// is fresh must end up with a `data.json`: the device is marked indexed
+		// either way, so a second launch that found no file would take the
+		// `absent && hasIndex` branch instead — read-only, with a notice telling
+		// the user their settings have gone missing when they never had any.
+		storage.clear();
+		const disk = new Disk();
+		const first = phone("new-phone", disk);
+		assert.strictEqual((await first.boot()).isFreshInstall, true);
+		assert.strictEqual(await first.layoutReady(), true);
+
+		// What `maybeShowWelcomeOnLaunch` does once the launch is confirmed.
+		first.registry.settings.welcomeSeen = true;
+		await first.save();
+		assert.ok(disk.content !== null, "a confirmed fresh install wrote nothing");
+
+		const second = phone("new-phone", disk);
+		assert.strictEqual((await second.boot()).isFreshInstall, false);
+		second.registry.add(authored("made-on-the-second-launch"));
+		await second.save();
+		assert.ok(
+			(disk.content ?? "").includes("made-on-the-second-launch"),
+			"the second launch came up read-only",
 		);
 	});
 
@@ -250,10 +304,10 @@ describe("a phone whose data.json has not arrived", () => {
 
 describe("a data.json that turns up after startup", () => {
 	it("is adopted rather than replaced with the defaults", async () => {
-		// The remaining shape of #53: a device this vault has only just reached,
-		// so there is no device index to say the file ever existed. It arrives
-		// between `onload` and the first write, and the first write is what
-		// `stillFreshInstall` gates. See settings/welcomeRouting.ts.
+		// The shape of #53: a device this vault has only just reached, so there
+		// is no device index to say the file ever existed. It arrives between
+		// `onload` and `onLayoutReady` — the window the launch spends frozen,
+		// waiting to find out which of the two it is.
 		storage.clear();
 		const disk = new Disk();
 		const p = phone("new-phone", disk);
@@ -266,7 +320,7 @@ describe("a data.json that turns up after startup", () => {
 		disk.content = arrived.content;
 
 		assert.strictEqual(
-			await stillFreshInstall(p.host),
+			await p.layoutReady(),
 			false,
 			"still believed it was a fresh install",
 		);
@@ -282,7 +336,7 @@ describe("a data.json that turns up after startup", () => {
 
 		disk.content = '{"version":4,"callouts":[{"id":"tru';
 
-		assert.strictEqual(await stillFreshInstall(p.host), false);
+		assert.strictEqual(await p.layoutReady(), false);
 		p.registry.add(authored("made-after-the-failure"));
 		await p.save();
 		assert.strictEqual(disk.writes, 0, "replaced a file it could not read");
@@ -294,9 +348,10 @@ describe("a data.json that turns up after startup", () => {
 	});
 
 	it("stops the welcome flow from creating one over it", async () => {
-		// The wiring, not just the check. `welcomeSeen` is the first thing a
-		// fresh install writes, so if this seam does not hold, nothing else
-		// downstream gets the chance to.
+		// The wiring, not just the check: `main.ts` runs the confirmation and
+		// hands its answer to the welcome, which no longer re-reads anything of
+		// its own. If that seam does not hold, `welcomeSeen` is written over the
+		// file that just arrived and nothing downstream gets a chance to help.
 		storage.clear();
 		const disk = new Disk();
 		const p = phone("new-phone", disk);
@@ -305,6 +360,11 @@ describe("a data.json that turns up after startup", () => {
 		const arrived = vaultWithUserCallouts();
 		disk.content = arrived.content;
 		const fileBefore = disk.content;
+
+		const freshInstall = boot.isFreshInstall
+			? await p.layoutReady()
+			: false;
+		assert.strictEqual(freshInstall, false, "greeted an existing vault");
 
 		// `main.ts` exposes `settings` off the registry, and the routing reads
 		// `welcomeSeen` from it. `WelcomeModal` is never constructed on this
@@ -320,7 +380,7 @@ describe("a data.json that turns up after startup", () => {
 			welcomeHost as unknown as Parameters<
 				typeof maybeShowWelcomeOnLaunch
 			>[0],
-			boot.isFreshInstall,
+			freshInstall,
 		);
 
 		assert.strictEqual(disk.writes, 0, "welcome wrote over the real file");
@@ -363,6 +423,7 @@ describe("a data.json that turns up after startup", () => {
 		const disk = new Disk();
 		const p = phone("new-phone", disk);
 		await p.boot();
+		await p.layoutReady();
 
 		p.registry.add(authored("first-one"));
 		await p.save();
@@ -386,7 +447,7 @@ describe("a data.json that turns up after startup", () => {
 		const p = phone("new-phone", disk);
 		await p.boot();
 
-		assert.strictEqual(await stillFreshInstall(p.host), true);
+		assert.strictEqual(await p.layoutReady(), true);
 		p.registry.add(authored("first-one"));
 		await p.save();
 		assert.ok(disk.writes > 0, "a real fresh install was blocked");

--- a/tests/syncPingPong.test.ts
+++ b/tests/syncPingPong.test.ts
@@ -36,6 +36,7 @@ import {
 	adoptExternalSettings,
 	loadSettingsInto,
 } from "../src/manager/settingsBoot";
+import { confirmFreshInstall } from "../src/manager/settingsLateArrival";
 import type { ExternalReloadHost } from "../src/manager/settingsBoot";
 import type { CalloutDefinition, IconSvgCacheEntry } from "../src/types";
 
@@ -153,6 +154,13 @@ function device(name: string, disk: Disk) {
 		writer,
 		/** The startup path. */
 		boot: () => loadSettingsInto(host),
+		/**
+		 * `main.ts`'s `onLayoutReady`, which is where a launch that found no
+		 * settings file settles whether it really is a fresh install. Until it
+		 * runs, that launch is frozen and writes nothing — so a harness that
+		 * stops at `boot()` is modelling half a launch.
+		 */
+		layoutReady: () => confirmFreshInstall(host),
 		/** The sync client landing the other device's file here. */
 		adopt: () => adoptExternalSettings(host),
 		save: () => writer.save(),
@@ -220,6 +228,11 @@ async function world() {
 	const b = device("B", disk);
 	await a.boot();
 	await b.boot();
+	// Both found an empty folder, so both came up frozen. A real launch resolves
+	// that at `onLayoutReady`; without this the world starts read-only and every
+	// convergence test below passes for the wrong reason.
+	await a.layoutReady();
+	await b.layoutReady();
 	return { disk, a, b, all: [a, b] };
 }
 


### PR DESCRIPTION
Closes the mechanism issue #53 actually runs on. 2.12.1 guarded the *one write that creates the file*; this guards the session.

### What was still broken

On the `absent` boot path `applySettingsRead` never calls `adopt()`, so `SaveGuard.last` stays `null` and the dedup guard suppresses **nothing** until the first successful write. Meanwhile `void this.icons.initialize()` is unordered against `onLayoutReady`, and `IconFetchManager` calls `saveSettings()` as soon as it has artwork — as does any `css-change` theme sweep reaching `registry.onChange`.

So a background write could create `data.json` from the shipped defaults **before `maybeShowWelcomeOnLaunch` ever ran its `stillFreshInstall` re-check**. The guard was bypassable, and the sync client carried the loss to every other device.

New test `writes nothing before the launch has confirmed it is fresh` reproduces exactly that and fails on the pre-fix code.

### Why not a pre-write check in SettingsWriter

That was the obvious repair and it **deadlocks**. `runPass` is what `inFlight` holds; a check that adopts calls `reloadFrom`, whose `hold()` releases with `await this.save()`, and that `save()` — seeing `inFlight` set — returns a `followUp` chained on the very `runPass` awaiting it. A closed promise cycle, on precisely the path the check exists for. It would hang inside `onLayoutReady`, so the session would also silently lose its discovery watchers.

`frozen` is the only writer-level gate that is safe here, because it is a synchronous boolean read at the top of `save()` — a re-entrant save resolves immediately instead of joining a promise the gate is awaiting.

### The fix

- `loadSettingsInto` freezes the writer on the fresh-install branch too. The freeze is **provisional** and lasts under a second.
- New `confirmFreshInstall` ends it at `onLayoutReady`: `thaw()` if the folder is still empty, an adoption if the file arrived, stay frozen if what arrived is unreadable. It returns `false` without reading when the writer is no longer frozen — something already adopted a file, so there is nothing to confirm and nobody to greet.
- `welcomeRouting` drops its own re-check; `isFreshInstall` now arrives already confirmed.
- A throw inside the confirmation thaws anyway and treats the launch as fresh: `readSettingsFile` already funnels adapter failures into `unreadable`, so a throw is genuinely exceptional — and leaving that freeze in place would mean a fresh install keeping nothing, this launch and every launch after it, since no file would ever be created.

Nothing is lost by suppressing rather than deferring: `runPass` builds its payload at write time, so anything mutated during the freeze rides the first write after it.

**`confirmFreshInstall` must only ever be called for this freeze.** The `absent && hasIndex` freeze reports "still nothing there" too, and thawing it would write the built-ins over settings that have merely gone missing. Documented as a warning on the function and gated at the one call site.

### New module

`manager/launchSequence.ts` — the post-layout half of startup (confirm → welcome → first-run discovery), extracted because the ordering rule between those three is now load-bearing and `main.ts` is wiring. `main.ts` drops 512 → 503 lines and the ratchet in `repoSourceRules` is lowered to match.

### Tests

- `writes nothing before the launch has confirmed it is fresh` — the H1 window. Verified failing pre-fix.
- `leaves the next launch of a confirmed fresh install alone` — the opposite direction, and the reason the welcome's write is load-bearing: the device is marked indexed either way, so a second launch finding no file would take the `absent && hasIndex` branch and tell the user their settings went missing when they never had any.
- Both sync harnesses gained `layoutReady()`. They modelled `onload` only, so every convergence test in `syncPingPong` was starting read-only and would have passed for the wrong reason.

`npm test` 4642 pass / 1 fail; `tsc` and `lint` clean. The failure is `main.js stays inside its budget`, which fails identically on `master` — the local `main.js` is a gitignored `npm run dev` build. Also verified `src/main.ts` still bundles, since no test imports the new module.