### PR TITLE
Correct the settings scroller claim, throttle repaint prunes

### DIFF
--- a/internals-docs/15-settings-ui-and-modals.md
+++ b/internals-docs/15-settings-ui-and-modals.md
@@ -117,7 +117,7 @@ which `keepHeadingInPlace` already anchors.
 
 ```ts
 scanOpenEditorsForUnknownCallouts(this.app, this.plugin);  // sections/openEditorDiscovery.ts
-this.plugin.schedulePruneUnusedFallbacks(0);
+this.plugin.schedulePruneUnusedFallbacks(this.unsubscribe === null ? 0 : undefined);
 ```
 
 Opening the settings tab **scans every open editor's in-memory buffer** for
@@ -156,6 +156,20 @@ list back to its first 20 rows. Two things answer that:
   a still-short page would be clamped and lost. It is self-limiting rather than
   stateful: a freshly opened pane is already at 0, so a genuine open restores
   nothing and behaves exactly as it always has.
+
+  > [!NOTE]
+  > `containerEl` **is** the scroller, on phones as much as anywhere else, so
+  > reading `scrollTop` off it directly is right and does not need
+  > `foldAnchor`'s `scrollParentOf`. Verified against Obsidian 1.13.7: the tab's
+  > container is `createDiv("vertical-tab-content")`, the only two overflow
+  > rules on the pair are `.vertical-tab-content-container { overflow: hidden }`
+  > and `.vertical-tab-content { overflow-y: auto; height: 100% }` with no
+  > mobile override, and `vertical-tab-content-inner` — which `foldAnchor` used
+  > to warn "could move the overflow up to the container" — appears **zero**
+  > times in `app.js` and only ever as a *descendant* of the scroller in
+  > `app.css`, for the phone's rounded-card look. That warning was wrong in both
+  > halves and is corrected in place, because it points a reader at the wrong
+  > element when they go looking for a scroll bug.
 - **Paging.** The cursors moved out of the controller closure and onto
   `SettingsTab` — see
   [Where the state lives, and how long](#where-the-state-lives-and-how-long).
@@ -613,9 +627,9 @@ not that. (Saved color palettes keeps its own single cursor in
 
 The **fold** is not session-only. `settings/sections/calloutListsFold.ts`
 mirrors each section's `SectionDisclosure` into
-`PluginSettings.calloutListsExpanded` (`{ theme, user, builtin, palettes }` —
-the first three keyed the same way as `RowKind`, `palettes` added for Saved
-color palettes) the moment the user folds or unfolds it by hand —
+`DeviceLocalStore.listsExpanded` (`{ theme, user, builtin, palettes }` — the
+first three keyed the same way as `RowKind`, `palettes` added for Saved color
+palettes) the moment the user folds or unfolds it by hand —
 `attachSectionDisclosure`'s `onToggle` fires only on that user gesture, never
 when a caller drives `setExpanded` programmatically, so a save only happens
 for a choice the user actually made. `attachPersistedFold` takes any
@@ -624,10 +638,16 @@ for a choice the user actually made. `attachPersistedFold` takes any
 itself to a concept it has nothing to do with. Both `createCalloutListsController`
 and `renderCustomPalettesSection` read the relevant field back as their
 heading's `initiallyExpanded` on render, so a folded section stays folded
-across a settings-tab reopen and a plugin reload alike; an install upgrading
-from before a given key existed merges in `true` for it
-(`mergeSavedSettings`, `DEFAULT_SETTINGS.calloutListsExpanded`), so the tab
-looks exactly as it did before the upgrade.
+across a settings-tab reopen and a plugin reload alike; a device whose stored
+blob predates a given key defaults it to `true` field by field
+(`DeviceLocalStore.read`), so the tab looks exactly as it did before the
+upgrade.
+
+It lives in `localStorage` rather than `data.json` precisely because it is
+per-device: folding a section away used to rewrite the synced settings file,
+which on a synced vault is one more file event for the sync client to
+reconcile, and what is folded on a phone has nothing to say to a desktop. See
+[Persistence § the device-local store](07-persistence-and-caching.md).
 
 The heading count is always the full list a section has — the partitioned
 length for a callout list, `settings.customPalettes.length` for Saved color

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -118,12 +118,14 @@ export class CalloutStudioSettingsTab extends PluginSettingTab {
 		containerEl.empty();
 		containerEl.addClass("callout-studio-settings");
 
-		scanOpenEditorsForUnknownCallouts(this.app, this.plugin);
-		this.plugin.schedulePruneUnusedFallbacks(0);
+		// Two things below are owed to a *visit*, not a render: `display()`
+		// re-runs for a synced settings file or a locale download, and neither
+		// may stack a listener or skip the prune floor. See internals-docs/15.
+		const visit = this.unsubscribe === null;
 
-		// Once per visit, not per render: `display()` re-runs for things the
-		// reader did not ask for, and re-subscribing on each would stack
-		// duplicate listeners for the life of the session.
+		scanOpenEditorsForUnknownCallouts(this.app, this.plugin);
+		this.plugin.schedulePruneUnusedFallbacks(visit ? 0 : undefined);
+
 		this.unsubscribe ??= subscribeSettingsTab(
 			this.app,
 			this.plugin,

--- a/src/settings/sections/CalloutListsSection.ts
+++ b/src/settings/sections/CalloutListsSection.ts
@@ -33,10 +33,12 @@
  * every row on a registry change or a theme switch, and a list the user had
  * expanded must not quietly fold back up under them.
  *
- * The fold is written through to `settings.calloutListsExpanded`
+ * The fold is written through to `DeviceLocalStore.listsExpanded`
  * (`calloutListsFold.ts`) on every user-driven toggle, so it survives a
  * settings-tab reopen or a plugin reload — each section starts from whatever
- * the user last left it, not from expanded.
+ * the user last left it, not from expanded. Device-local, not in `data.json`:
+ * what is folded on a phone has nothing to say to a desktop, and folding a
+ * section used to be a write to a synced file.
  *
  * The paging cursor is deliberately not persisted: it is session-only, reset
  * by that same reopen. But it is *held by `SettingsTab`* rather than by this

--- a/src/settings/sections/calloutListsFold.ts
+++ b/src/settings/sections/calloutListsFold.ts
@@ -1,6 +1,6 @@
 /**
  * settings/sections/calloutListsFold.ts — the settings tab's collapsible
- * headings, backed by `settings.calloutListsExpanded` instead of a closure
+ * headings, backed by `DeviceLocalStore.listsExpanded` instead of a closure
  * that dies with the settings tab.
  *
  * `sectionDisclosure.ts` stays settings-agnostic — a plain foldable heading,

--- a/src/settings/sections/foldAnchor.ts
+++ b/src/settings/sections/foldAnchor.ts
@@ -34,9 +34,26 @@
  * The settings pane by name first: Obsidian's `.vertical-tab-content` is both
  * the scroller and, on a plugin tab, the element the plugin renders into (see
  * `SettingsTab.display`), and `hotkeyLink` already reaches for the same pair.
- * The walk behind it is what keeps this honest if that stops being true — a
- * phone puts a `.vertical-tab-content-inner` in between, and the overflow could
- * move up to the container.
+ * The walk behind it is what keeps this honest if that ever stops being true.
+ *
+ * It is true on **every** platform, phones included, and this comment used to
+ * say otherwise — that a phone puts a `.vertical-tab-content-inner` in between
+ * and the overflow "could move up to the container". Checked against Obsidian
+ * 1.13.7's own `app.css` and `app.js`, that is wrong in both halves, and the
+ * mistake is worth recording because it points a reader at the wrong element:
+ *
+ * - `.vertical-tab-content-container { overflow: hidden }` and
+ *   `.vertical-tab-content { overflow-y: auto; height: 100% }` are the only two
+ *   overflow rules on either class, with no mobile override. The overflow does
+ *   not move.
+ * - `.vertical-tab-content-inner` is styled only under
+ *   `.is-phone .modal.mod-settings .vertical-tab-content .vertical-tab-content-inner`
+ *   — a *descendant* of the scroller, for the rounded card look — and the
+ *   string does not appear in `app.js` at all, so nothing creates it on the
+ *   path a plugin tab takes.
+ *
+ * `SettingsTab.display` therefore reads and writes `containerEl.scrollTop`
+ * correctly as it stands. See `internals-docs/15-settings-ui-and-modals.md`.
  */
 function scrollParentOf(el: HTMLElement): HTMLElement | null {
 	const known = el.closest<HTMLElement>(


### PR DESCRIPTION
**The hypothesis this branch set out to fix turned out to be wrong, so it does not fix it.** What it ships instead is the evidence, so nobody spends the time again, plus one real improvement found along the way.

### What I expected to find

`display()` saves and restores `containerEl.scrollTop`, while the *refresh* path resolves the scroller with `scrollParentOf`. That function's docblock said a phone puts a `.vertical-tab-content-inner` in between and "the overflow could move up to the container" — which would mean `display()`'s save reads `0`, the `if (scrollTop > 0)` restore is skipped, and the full-redraw path silently no-ops on exactly the platform the bug was reported from.

### What is actually true

Checked against Obsidian 1.13.7, extracted from the installer asar:

- `app.js`: the tab's container is `createDiv("vertical-tab-content")`, inside `.vertical-tab-content-container`.
- `app.css`: the **only** two overflow rules on that pair are `.vertical-tab-content-container { overflow: hidden }` and `.vertical-tab-content { overflow-y: auto; height: 100% }`. No mobile override — I checked every rule matching either class.
- `vertical-tab-content-inner` appears **zero** times in `app.js`, so nothing creates it on the path a plugin tab takes, and in `app.css` it is only ever a *descendant* of the scroller (`.is-phone … .vertical-tab-content .vertical-tab-content-inner`), for the rounded-card look.

So `containerEl` **is** the scroller, phones included, and `display()` reads and writes the right element as it stands. `scrollParentOf` would return `containerEl` anyway — `closest()` matches the element itself.

I could not identify a remaining scroll defect from the code, so I have not invented a fix for one. The comment is corrected in place with the evidence, because it points a reader at the wrong element the moment they go looking.

### The one real change

`display()` called `schedulePruneUnusedFallbacks(0)` on every render. That `0` deliberately skips `CalloutPrune`'s ten-second floor, and `CalloutPrune`'s own comment says why: the exemption is for "a user standing in front of the list they are about to look at."

But `display()` is also re-run by `reloadFrom` when another device's settings file lands, and by a locale download. Neither is that user — and on mobile the exemption puts an immediate whole-vault `cachedRead` + tokenize on the main thread, which is the exact cost `PRUNE_DELAY_MS = 10000` exists to avoid.

Gated on `this.unsubscribe === null`, the marker that already distinguishes a visit from a repaint (set once per visit by the `??=` below, cleared in `hide()`). A repaint still gets a prune, just the throttled one — nothing is lost, only the urgency. The open-editor scan stays on every render: it reads open buffers, not the vault.

### Also corrected: docs that were already stale

The fold state moved to `DeviceLocalStore.listsExpanded` a while ago, but three places still said `PluginSettings.calloutListsExpanded`, a field that no longer exists — `internals-docs/15` (twice) and the header comments of `CalloutListsSection.ts` and `calloutListsFold.ts`.

### Coverage debt, stated rather than hidden

`CalloutStudioSettingsTab` is constructed by **no test in the repo**, so `display()` has no coverage and this change has none either. I tried to add the first one: the tab builds and `display()` runs as far as the section renderers, then dies on `Setting.addDropdown` — `tests/support/obsidianStub.ts`'s `Setting` has only `setName/setDesc/setClass/setHeading/addButton/addExtraButton/addSlider`. Getting through eleven renderers means building `addDropdown`/`addToggle`/`addText`/… into a stub 140 suites share. That is a harness project, not a line in this PR, so I dropped the attempt rather than rush shared infrastructure. Worth doing on its own.

`npm test` 4642 pass / 1 fail; `tsc` and `lint` clean. The failure is `main.js stays inside its budget`, which fails identically on `master` — the local `main.js` is a gitignored `npm run dev` build.