### PR TITLE
Collapse three write memos and the ownership check

### DIFF
--- a/internals-docs/07-persistence-and-caching.md
+++ b/internals-docs/07-persistence-and-caching.md
@@ -79,6 +79,18 @@ four rules the raw `saveData` call did not:
   after a write *succeeds*, so a failed write is retried rather than suppressed
   forever.
 
+  That last rule is not specific to `data.json`. All three stores the plugin
+  writes keep the same baseline — this one, the device-local blob and the
+  startup CSS snapshot — so it lives in
+  [`utils/writeMemo.ts`](../src/utils/writeMemo.ts) and the three hold a
+  `WriteMemo` rather than a `string | null` of their own. They had a field, a
+  compare and a copy of the explanation each, and `StartupStyleCache` is where
+  that cost something: it recorded the value *before* offering it to storage, so
+  a refused write was remembered as a success and that text was never offered
+  again for the rest of the session. `SaveGuard` stays as the `data.json` face
+  over it, because what it adds — serializing the object, and the
+  `commit`/`adopt` vocabulary issue #41 turned on — is worth its own name.
+
   > [!IMPORTANT]
   > An external change **re-seeds** the baseline; it must never *clear* it.
   > `SaveGuard` used to expose `invalidate()` for exactly that, on the reasoning
@@ -150,6 +162,13 @@ row being edited underneath the user — and `pruneSuspended`, the flag that say
 so, is the only seam that re-runs a deferred reload, which is why the two
 previewing modals raise it too ([`settings/previewOwnership.ts`](../src/settings/previewOwnership.ts))
 rather than leaving `pendingExternalReload` latched for the session.
+
+Both adoption paths ask that question, so both ask it through
+[`manager/registryOwnership.ts`](../src/manager/registryOwnership.ts)'s
+`registryIsOwned` — `previewOwnership.ts` is the writing side of the same flag,
+this is the reading side. They differ only in the answer: `adoptExternalSettings`
+reports the adoption as *deferred* so `main.ts` can re-run it when the flag
+drops, while the foreground check simply waits for the next return to the app.
 
 The order inside it is load bearing twice over: the theme sweep runs **before**
 `customCommands.syncAll()`, because `syncAll` drops any command whose callout

--- a/src/manager/DeviceLocalStore.ts
+++ b/src/manager/DeviceLocalStore.ts
@@ -29,6 +29,7 @@
 import type { App } from "obsidian";
 import type { CalloutListsFoldState } from "../types";
 import { calloutIdentity, mergeDashSpaceVariants } from "../utils/calloutId";
+import { WriteMemo } from "../utils/writeMemo";
 import {
 	recordRetiredThemeIds,
 	sanitizeRetiredThemeIds,
@@ -107,8 +108,12 @@ export class DeviceLocalStore {
 	 * indexed here".
 	 */
 	private indexed: boolean;
-	/** Last string handed to storage — dedupes the writes discovery repeats. */
-	private lastPersisted: string | null = null;
+	/**
+	 * What the stored blob is believed to hold — dedupes the writes discovery
+	 * repeats. See utils/writeMemo.ts for why it only moves after a write
+	 * lands, and why reading a store back counts as learning the same thing.
+	 */
+	private readonly memo = new WriteMemo();
 
 	constructor(private readonly app: App) {
 		const raw = this.read();
@@ -116,7 +121,7 @@ export class DeviceLocalStore {
 		this.state = raw ?? structuredClone(EMPTY);
 		// Seed the memo from what is already stored, so the startup pass
 		// re-asserting an unchanged index costs no write at all.
-		if (raw !== null) this.lastPersisted = JSON.stringify(this.state);
+		if (raw !== null) this.memo.adopt(JSON.stringify(this.state));
 	}
 
 	/**
@@ -270,12 +275,12 @@ export class DeviceLocalStore {
 
 	private persist(): void {
 		const json = JSON.stringify(this.state);
-		if (json === this.lastPersisted) return;
+		if (this.memo.prepare(json) === null) return;
 		try {
 			window.localStorage.setItem(this.scopedKey(), json);
 			// Only after the write landed — a refused write must be retried, not
-			// remembered as a success. See StartupStyleCache.persist.
-			this.lastPersisted = json;
+			// remembered as a success. See utils/writeMemo.ts.
+			this.memo.commit(json);
 			this.indexed = true;
 		} catch {
 			// Storage full or unavailable. The rows are already in the registry

--- a/src/manager/StartupStyleCache.ts
+++ b/src/manager/StartupStyleCache.ts
@@ -22,14 +22,16 @@
  * legacyStartupSnippet.ts, which cleans up what it left behind.
  */
 import type { App } from "obsidian";
+import { WriteMemo } from "../utils/writeMemo";
 
 const LOCAL_STORAGE_KEY = "callout-studio-css";
 
 export class StartupStyleCache {
 	private app: App;
-	/** Last CSS handed to persist() — dedupes the no-op injects that follow
-	 * every external css-change event. */
-	private lastPersisted: string | null = null;
+	/** What the snapshot is believed to hold — dedupes the no-op injects that
+	 * follow every external css-change event. See utils/writeMemo.ts, which
+	 * also records why this must only move after a write lands. */
+	private readonly memo = new WriteMemo();
 
 	constructor(app: App) {
 		this.app = app;
@@ -60,20 +62,15 @@ export class StartupStyleCache {
 
 	/** Record freshly generated CSS for the next launch's fast path. */
 	persist(cssText: string): void {
-		if (cssText === this.lastPersisted) return;
+		if (this.memo.prepare(cssText) === null) return;
 		try {
 			window.localStorage.setItem(
 				this.scopedKey(LOCAL_STORAGE_KEY),
 				cssText,
 			);
-			// Only once the write has actually landed. Raised before the `try`,
-			// the memo remembered a refused write as a successful one — and
-			// since the memo is what makes a repeat inject a no-op, the same
-			// text was then never offered to storage again for the rest of the
-			// session. A store that frees up mid-session (the user deletes
-			// something, another plugin's quota is reclaimed) would have gone on
-			// launching without a snapshot until a style edit changed the text.
-			this.lastPersisted = cssText;
+			// Only once the write has actually landed — the rule, and the bug
+			// that produced it, are in utils/writeMemo.ts.
+			this.memo.commit(cssText);
 		} catch {
 			// Quota exceeded / storage unavailable — the normal inject path still
 			// works, so styling is never lost; only the fast path is skipped.

--- a/src/manager/registryOwnership.ts
+++ b/src/manager/registryOwnership.ts
@@ -1,0 +1,39 @@
+/**
+ * manager/registryOwnership.ts — "is a modal holding the registry right now?"
+ *
+ * Asked by both paths that can adopt a `data.json` mid-session — the desktop
+ * watcher's `adoptExternalSettings` and the mobile foreground check in
+ * `settingsLateArrival` — because both would otherwise rebuild the registry
+ * underneath a row the user is in the middle of editing, or underneath a demo
+ * callout a modal has stood up. They differ only in what they do about it:
+ * `adoptExternalSettings` reports the adoption as *deferred* so `main.ts` can
+ * re-run it when the flag drops, while the foreground check simply waits for
+ * the next time the user comes back.
+ *
+ * Two flags rather than one because they are raised by different owners.
+ * `pruneSuspended` is the callout editor and the two previewing modals (see
+ * `settings/previewOwnership.ts`, which is the *writing* side of the same
+ * question); `hasPreviewDefinition()` is the registry's own answer about a live
+ * preview slot. Either one means the same thing to a reload.
+ *
+ * Its own module, and structurally typed, because the alternative — an exported
+ * helper on `settingsBoot` — is a file already at the repo's size limit, and
+ * because the two copies of this expression had already started to drift in
+ * their comments while agreeing in their code.
+ */
+
+/** What answering the question needs. */
+export interface RegistryOwnershipHost {
+	/** True exactly while the callout editor or a previewing modal owns it. */
+	pruneSuspended: boolean;
+	registry: { hasPreviewDefinition(): boolean };
+}
+
+/**
+ * Whether something is holding the registry that a rebuild must not disturb.
+ *
+ * Callers must not adopt an incoming settings file while this is true.
+ */
+export function registryIsOwned(host: RegistryOwnershipHost): boolean {
+	return host.pruneSuspended || host.registry.hasPreviewDefinition();
+}

--- a/src/manager/settingsBoot.ts
+++ b/src/manager/settingsBoot.ts
@@ -31,6 +31,7 @@ import { bootDiscoveryIndex } from "./discoveryIndexBoot";
 import { readSettingsFile } from "./settingsFile";
 import { offerFreshStart, warnSettingsUnreadable } from "./settingsNotices";
 import { watchForLateSettings } from "./settingsLateArrival";
+import { registryIsOwned } from "./registryOwnership";
 import type { SettingsFileHost, SettingsRead } from "./settingsFile";
 
 /** What the load needs from the plugin. */
@@ -130,11 +131,10 @@ export async function loadSettingsInto(
 				"settings will not be written this session",
 		);
 		warnSettingsUnreadable();
-		// A file caught mid-write is finished moments later, and this is the
-		// only thing that will notice on a phone — Obsidian's config-folder
-		// watcher is desktop-only, so `onExternalSettingsChange` never fires
-		// there and the session would otherwise show no callouts until the user
-		// thought to restart the app.
+		// A file caught mid-write is finished moments later, and on a phone this
+		// is the only thing that will notice: the config-folder watcher behind
+		// `onExternalSettingsChange` is desktop-only, so the session would
+		// otherwise show no callouts until the user thought to restart.
 		watchForLateSettings(host);
 		return { isFreshInstall: false };
 	}
@@ -236,7 +236,7 @@ export interface ExternalReloadHost extends SettingsBootHost {
 export async function adoptExternalSettings(
 	host: ExternalReloadHost,
 ): Promise<boolean> {
-	if (host.pruneSuspended || host.registry.hasPreviewDefinition()) return true;
+	if (registryIsOwned(host)) return true;
 
 	const read = await readSettingsFile(host);
 

--- a/src/manager/settingsLateArrival.ts
+++ b/src/manager/settingsLateArrival.ts
@@ -37,6 +37,7 @@ import type { ExternalReloadHost } from "./settingsBoot";
 import { reloadFrom } from "./settingsBoot";
 import { readSettingsFile } from "./settingsFile";
 import { warnSettingsUnreadable } from "./settingsNotices";
+import { registryIsOwned } from "./registryOwnership";
 
 /**
  * Whether this is still the fresh install that startup took it for.
@@ -187,7 +188,7 @@ export function watchForLateSettings(host: ExternalReloadHost): void {
 
 		// The editor owns the registry right now; rebuilding under it would
 		// change the row being edited. Try again next time.
-		if (host.pruneSuspended || host.registry.hasPreviewDefinition()) return;
+		if (registryIsOwned(host)) return;
 
 		settled = true;
 		// `reloadFrom` thaws — see its docblock. Adopting is the one thing that

--- a/src/utils/saveGuard.ts
+++ b/src/utils/saveGuard.ts
@@ -9,45 +9,40 @@
  * started — the same argument `cssSnippetExport` already makes for the CSS
  * snippet and `StartupStyleCache` makes for the startup snapshot.
  *
- * The baseline is **the bytes we believe `data.json` currently holds**. Two
- * different events establish that belief, which is why there are two setters
- * with the same one-line body and deliberately different names:
+ * The shared discipline — a baseline that moves only after a write lands, and
+ * that an external write re-seeds rather than clears — lives in
+ * [`utils/writeMemo.ts`](./writeMemo.ts), because those same three stores all
+ * need it. What is specific to `data.json`, and stays here, is that the thing
+ * being compared is a **serialized object** rather than text the caller already
+ * holds, and the reason the distinction between the two setters is worth its
+ * own vocabulary:
  *
  * - {@link commit} — *we* wrote those bytes, and the write landed.
  * - {@link adopt} — *someone else* wrote them and we have just read them back,
  *   so they are the truth now whatever we last wrote ourselves.
  *
- * Two rules this guard exists to get right:
- *
- * - **The baseline moves only after a write succeeds.** `prepare()` hands back
- *   the serialized payload and `commit()` records it, so a throwing write
- *   leaves the baseline where it was and the next attempt tries again rather
- *   than being suppressed as a duplicate forever.
- * - **An external change re-seeds the baseline; it does not clear it.** This
- *   file used to expose `invalidate()`, which nulled the baseline so that the
- *   next save wrote unconditionally. That was the engine of issue #41's second
- *   failure: `onExternalSettingsChange` called it, the reload then re-added this
- *   device's discovered rows, the resulting `onChange` asked for a save, and the
- *   guard — having just been switched off — wrote the file straight back at the
- *   device that had sent it. Both devices did this to each other, forever.
- *
- *   `adopt()` keeps the safety property `invalidate()` was reaching for while
- *   removing the loop: a save whose payload *reproduces* the adopted file is
- *   suppressed (it asserts nothing and is pure sync churn), and a save carrying
- *   genuinely different local state still writes, because its payload differs
- *   from the bytes on disk.
+ * > [!IMPORTANT]
+ * > **An external change re-seeds the baseline; it does not clear it.** This
+ * > file used to expose `invalidate()`, which nulled the baseline so that the
+ * > next save wrote unconditionally. That was the engine of issue #41's second
+ * > failure: `onExternalSettingsChange` called it, the reload then re-added this
+ * > device's discovered rows, the resulting `onChange` asked for a save, and the
+ * > guard — having just been switched off — wrote the file straight back at the
+ * > device that had sent it. Both devices did this to each other, forever.
+ * >
+ * > `adopt()` keeps the safety property `invalidate()` was reaching for while
+ * > removing the loop: a save whose payload *reproduces* the adopted file is
+ * > suppressed (it asserts nothing and is pure sync churn), and a save carrying
+ * > genuinely different local state still writes, because its payload differs
+ * > from the bytes on disk.
  *
  * Its own module, holding its own baseline, so `main.ts` keeps only the call
  * and the rule can be tested without standing up a plugin harness.
  */
+import { WriteMemo } from "./writeMemo";
 
 export class SaveGuard {
-	/**
-	 * Serialized form of what `data.json` is believed to hold, or null before
-	 * anything has established that — a session that has neither written nor
-	 * read the file.
-	 */
-	private last: string | null = null;
+	private readonly memo = new WriteMemo();
 
 	/**
 	 * The payload to write, or `null` when it is byte-identical to what the
@@ -58,13 +53,12 @@ export class SaveGuard {
 	 * migration.
 	 */
 	prepare(data: unknown): string | null {
-		const json = JSON.stringify(data);
-		return json === this.last ? null : json;
+		return this.memo.prepare(JSON.stringify(data));
 	}
 
 	/** Record a write that succeeded. Pass the string {@link prepare} returned. */
 	commit(json: string): void {
-		this.last = json;
+		this.memo.commit(json);
 	}
 
 	/**
@@ -77,7 +71,7 @@ export class SaveGuard {
 	 * preserves key order, which is what makes the two comparable at all.
 	 */
 	adopt(json: string): void {
-		this.last = json;
+		this.memo.adopt(json);
 	}
 
 	/**
@@ -89,6 +83,6 @@ export class SaveGuard {
 	 * repeating it for a file that cannot have changed anything.
 	 */
 	matches(json: string): boolean {
-		return json === this.last;
+		return this.memo.matches(json);
 	}
 }

--- a/src/utils/writeMemo.ts
+++ b/src/utils/writeMemo.ts
@@ -1,0 +1,64 @@
+/**
+ * utils/writeMemo.ts — "we already wrote exactly this, don't write it again."
+ *
+ * Three places in the plugin keep the same small piece of state: the text they
+ * believe is currently in a store, so a write carrying identical content can be
+ * skipped. `data.json` (via `utils/saveGuard.ts`), the device-local blob
+ * (`manager/DeviceLocalStore.ts`) and the startup CSS snapshot
+ * (`manager/StartupStyleCache.ts`). Each had its own field, its own compare and
+ * its own copy of the comment below, which is how one of them ended up with the
+ * rule backwards.
+ *
+ * Skipping matters for different reasons in each — a redundant `data.json`
+ * write is a sync event for another device to reconcile, a redundant
+ * `localStorage` write is main-thread work on a phone — but the rule is the
+ * same one, so it is written down once.
+ *
+ * **The baseline moves only after a write succeeds.** {@link prepare} hands
+ * back the text to write and {@link commit} records it, so a write that throws
+ * — a quota, a private window, a failing adapter — leaves the baseline where it
+ * was and the next attempt tries again. `StartupStyleCache` had this inverted
+ * once: it recorded the value before offering it to storage, so a refused write
+ * was remembered as a success and that text was never offered again for the
+ * rest of the session.
+ *
+ * **A value someone else stored is {@link adopt}ed, not ignored.** The point of
+ * the baseline is what the store holds, not what we last did to it. Reading a
+ * store back and adopting what is there is as good a way to learn that as
+ * writing it — and for `data.json`, where another device can write the same
+ * file, it is the only correct one. See `utils/saveGuard.ts` for what clearing
+ * the baseline instead cost (issue #41).
+ */
+export class WriteMemo {
+	/**
+	 * What the store is believed to hold, or null before anything has
+	 * established that — nothing written and nothing read.
+	 */
+	private last: string | null = null;
+
+	/**
+	 * The text to write, or `null` when it is what the store already holds.
+	 *
+	 * Deliberately not a boolean: the caller passes the same string back to
+	 * {@link commit}, so the value that was compared is the value that gets
+	 * recorded, and the two cannot drift.
+	 */
+	prepare(text: string): string | null {
+		return text === this.last ? null : text;
+	}
+
+	/** Record a write of ours that landed. Pass what {@link prepare} returned. */
+	commit(text: string): void {
+		this.last = text;
+	}
+
+	/** Record what someone else stored, as we have just read it back. */
+	adopt(text: string): void {
+		this.last = text;
+	}
+
+	/** Whether `text` is exactly what the store is believed to hold. */
+	matches(text: string): boolean {
+		return text === this.last;
+	}
+}


### PR DESCRIPTION
Pure refactor. No behaviour change anywhere — every changed line is a one-to-one substitution, which is what the diff should be read for.

### Three copies of one rule

`SaveGuard`, `DeviceLocalStore` and `StartupStyleCache` each kept a `string | null` of "what the store is believed to hold", each with its own compare, its own commit-after-success, and its own copy of the explanation.

That duplication had already cost something. `StartupStyleCache`'s own comment records it: the memo was once raised *before* the value was offered to storage, so a refused write was remembered as a success — and since the memo is what makes a repeat inject a no-op, that text was never offered again for the rest of the session. A store that freed up mid-session went on launching without a snapshot until a style edit changed the text.

Now `utils/writeMemo.ts` holds the rule once — `prepare` / `commit` / `adopt` / `matches` — and the three hold a `WriteMemo`. `SaveGuard` stays as the `data.json` face over it, because what it adds is worth its own name: it serializes the object, and it carries the `commit`-vs-`adopt` vocabulary that issue #41 turned on.

### Two copies of one question

`adoptExternalSettings` and `settingsLateArrival`'s foreground check both asked `host.pruneSuspended || host.registry.hasPreviewDefinition()` — "is a modal holding the registry?" — and their comments had already started to drift while the code agreed. Both now call `manager/registryOwnership.ts`'s `registryIsOwned`. `settings/previewOwnership.ts` is the writing side of that flag; this is the reading side.

Its own module rather than an export from `settingsBoot`, because that file sits at the repo's 300-line limit.

### Why I am confident this is safe

- The code half of the diff is a substitution, line for line. Filtering comments out of `git diff` leaves nothing but renamed field accesses.
- All three consumers already had behavioural coverage, and it is the coverage that matters here: `saveGuard.test.ts` (10 cases, including "keeps the old baseline when a write is never committed" and both adopt semantics), `deviceLocalStore.test.ts` (including "refused write retried" and "unchanged index not rewritten" — the constructor `adopt` path), and `startupStyleCache.test.ts`.
- I did **not** add a `writeMemo.test.ts`. The primitive is exercised through three tested consumers, and a fourth suite restating the same assertions is the kind of duplication this PR exists to remove.
- Verified `src/main.ts` still bundles, since the two new modules are reached only from source.

`npm test` 4642 pass / 1 fail; `tsc` and `lint` clean. The failure is `main.js stays inside its budget`, which fails identically on `master` — the local `main.js` is a gitignored `npm run dev` build.